### PR TITLE
Escape hash character when rendering LaTex formatted equations

### DIFF
--- a/docs/.buildinfo
+++ b/docs/.buildinfo
@@ -1,4 +1,4 @@
 # Sphinx build info version 1
 # This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 6df82cdb6e3ab70d022614431807b4e8
+config: cd268fbdf8c44651e428ddc441ce49e7
 tags: 645f666f9bcd5a90fca523b33c5a78b7

--- a/docs/_static/documentation_options.js
+++ b/docs/_static/documentation_options.js
@@ -1,5 +1,5 @@
 const DOCUMENTATION_OPTIONS = {
-    VERSION: '1.2.3',
+    VERSION: '1.2.4',
     LANGUAGE: 'en',
     COLLAPSE_INDEX: false,
     BUILDER: 'html',

--- a/docs/base_classes.html
+++ b/docs/base_classes.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Figures in Calc Reports" href="figures.html" /><link rel="prev" title="Purpose and Background" href="purpose.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Base Classes - efficalc 1.2.3 documentation</title>
+        <title>Base Classes - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -830,7 +830,7 @@ provided to the calculation runner or in the design portal on the cloud version 
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/calculation_helpers.html
+++ b/docs/calculation_helpers.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Section Properties" href="section_properties.html" /><link rel="prev" title="Drawing on a Canvas" href="canvas.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Calculation Helpers - efficalc 1.2.3 documentation</title>
+        <title>Calculation Helpers - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -491,7 +491,7 @@ the default value.</p>
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/canvas.html
+++ b/docs/canvas.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Calculation Helpers" href="calculation_helpers.html" /><link rel="prev" title="Figures in Calc Reports" href="figures.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Drawing on a Canvas - efficalc 1.2.3 documentation</title>
+        <title>Drawing on a Canvas - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -930,7 +930,7 @@ or “context-fill” to match the fill or stroke of the element this marker is 
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/constants.html
+++ b/docs/constants.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Styling Reports" href="styling.html" /><link rel="prev" title="Math Operations" href="math_operations.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Constants and Unit Conversions - efficalc 1.2.3 documentation</title>
+        <title>Constants and Unit Conversions - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -369,7 +369,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="prev" title="Testing Your Calculations" href="testing.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Examples - efficalc 1.2.3 documentation</title>
+        <title>Examples - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -302,7 +302,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/figures.html
+++ b/docs/figures.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Drawing on a Canvas" href="canvas.html" /><link rel="prev" title="Base Classes" href="base_classes.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Figures in Calc Reports - efficalc 1.2.3 documentation</title>
+        <title>Figures in Calc Reports - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -459,7 +459,7 @@ should be compatible with html image tags (e.g. .png, .jpg, .svg, .gif, etc.).</
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/genindex.html
+++ b/docs/genindex.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="#" /><link rel="search" title="Search" href="search.html" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Index - efficalc 1.2.3 documentation</title>
+    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Index - efficalc 1.2.4 documentation</title>
 <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -124,7 +124,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -150,7 +150,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -750,7 +750,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/get_started.html
+++ b/docs/get_started.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Purpose and Background" href="purpose.html" /><link rel="prev" title="efficalc" href="index.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Quickstart - efficalc 1.2.3 documentation</title>
+        <title>Quickstart - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -353,7 +353,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Quickstart" href="get_started.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>efficalc 1.2.3 documentation</title>
+        <title>efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="#"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="#"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -333,7 +333,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/integration.html
+++ b/docs/integration.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Testing Your Calculations" href="testing.html" /><link rel="prev" title="Styling Reports" href="styling.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Integrating and Extending efficalc - efficalc 1.2.3 documentation</title>
+        <title>Integrating and Extending efficalc - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -485,7 +485,7 @@ c = (sum)² = (7)²
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/math_operations.html
+++ b/docs/math_operations.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Constants and Unit Conversions" href="constants.html" /><link rel="prev" title="Section Properties" href="section_properties.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Math Operations - efficalc 1.2.3 documentation</title>
+        <title>Math Operations - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -650,7 +650,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/purpose.html
+++ b/docs/purpose.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Base Classes" href="base_classes.html" /><link rel="prev" title="Quickstart" href="get_started.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Purpose and Background - efficalc 1.2.3 documentation</title>
+        <title>Purpose and Background - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -369,7 +369,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/py-modindex.html
+++ b/docs/py-modindex.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Python Module Index - efficalc 1.2.3 documentation</title>
+    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Python Module Index - efficalc 1.2.4 documentation</title>
 <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -124,7 +124,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -150,7 +150,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -276,7 +276,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/search.html
+++ b/docs/search.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1"/>
     <meta name="color-scheme" content="light dark"><link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="#" />
 
-    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Search - efficalc 1.2.3 documentation</title><link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
+    <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 --><title>Search - efficalc 1.2.4 documentation</title><link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo-extensions.css?v=36a5483c" />
@@ -123,7 +123,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -149,7 +149,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="#" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -254,7 +254,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/section_properties.html
+++ b/docs/section_properties.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Math Operations" href="math_operations.html" /><link rel="prev" title="Calculation Helpers" href="calculation_helpers.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Section Properties - efficalc 1.2.3 documentation</title>
+        <title>Section Properties - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -779,7 +779,7 @@ database.</p>
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/styling.html
+++ b/docs/styling.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Integrating and Extending efficalc" href="integration.html" /><link rel="prev" title="Constants and Unit Conversions" href="constants.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Styling Reports - efficalc 1.2.3 documentation</title>
+        <title>Styling Reports - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -336,7 +336,7 @@ variable names, then an escape sequence can be used with a forward slash before 
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs/testing.html
+++ b/docs/testing.html
@@ -6,7 +6,7 @@
 <link rel="index" title="Index" href="genindex.html" /><link rel="search" title="Search" href="search.html" /><link rel="next" title="Examples" href="examples.html" /><link rel="prev" title="Integrating and Extending efficalc" href="integration.html" />
 
     <link rel="shortcut icon" href="_static/favicon.ico"/><!-- Generated with Sphinx 7.2.6 and Furo 2024.01.29 -->
-        <title>Testing Your Calculations - efficalc 1.2.3 documentation</title>
+        <title>Testing Your Calculations - efficalc 1.2.4 documentation</title>
       <link rel="stylesheet" type="text/css" href="_static/pygments.css?v=a746c00c" />
     <link rel="stylesheet" type="text/css" href="_static/styles/furo.css?v=135e06be" />
     <link rel="stylesheet" type="text/css" href="_static/copybutton.css?v=76b2166b" />
@@ -126,7 +126,7 @@
       </label>
     </div>
     <div class="header-center">
-      <a href="index.html"><div class="brand">efficalc 1.2.3 documentation</div></a>
+      <a href="index.html"><div class="brand">efficalc 1.2.4 documentation</div></a>
     </div>
     <div class="header-right">
       <div class="theme-toggle-container theme-toggle-header">
@@ -152,7 +152,7 @@
     <img class="sidebar-logo" src="_static/efficalc.png" alt="Logo"/>
   </div>
   
-  <span class="sidebar-brand-text">efficalc 1.2.3 documentation</span>
+  <span class="sidebar-brand-text">efficalc 1.2.4 documentation</span>
   
 </a><form class="sidebar-search-container" method="get" action="search.html" role="search">
   <input class="sidebar-search" placeholder="Search" name="q" aria-label="Search">
@@ -330,7 +330,7 @@
       
     </aside>
   </div>
-</div><script src="_static/documentation_options.js?v=590429e0"></script>
+</div><script src="_static/documentation_options.js?v=928db92d"></script>
     <script src="_static/doctools.js?v=888ff710"></script>
     <script src="_static/sphinx_highlight.js?v=dc90522c"></script>
     <script src="_static/scripts/furo.js?v=32e29ea5"></script>

--- a/docs_src/conf.py
+++ b/docs_src/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "efficalc"
 copyright = "2024, Andrew Young"
 author = "Andrew Young"
-release = "1.2.3"
+release = "1.2.4"
 html_favicon = "_static/favicon.ico"
 
 # -- General configuration ---------------------------------------------------

--- a/efficalc/generate_html.py
+++ b/efficalc/generate_html.py
@@ -305,11 +305,15 @@ def _generate_canvas_html(item: Canvas) -> str:
 
 
 def _wrap_math(content: str) -> str:
-    return rf"\[ {content} \]"
+    return rf"\[ {_escape_tex_characters(content)} \]"
 
 
 def _wrap_math_inline(content: str) -> str:
-    return rf"\( {content} \)"
+    return rf"\( {_escape_tex_characters(content)} \)"
+
+
+def _escape_tex_characters(content: str) -> str:
+    return content.replace("#", "\\#")
 
 
 def _wrap_with_reference(primary_content: str, reference: str | None) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "efficalc"
-version = "1.2.2"
+version = "1.2.4"
 authors = [
   { name="Andrew Young", email="youandvern@gmail.com" },
 ]

--- a/tests/test_generate_html.py
+++ b/tests/test_generate_html.py
@@ -514,3 +514,32 @@ def test_table_with_row_numbers_without_headers(common_setup_teardown):
     assert "<table" in result
     assert "<tr><td>1</td><td>f</td></tr>" in result
     assert "2</td>" not in result
+
+
+def test_inline_equation_escapes_hash_character(common_setup_teardown):
+    a = Input("calc#", 5, "in", "describing text", "refer to code")
+    result = generate_html_for_calc_items([a])
+    assert r"calc\#" in result
+    assert r"calc#" not in result
+    assert a.description in result
+    assert "[" + a.reference + "]" in result
+
+
+def test_equation_escapes_hash_character(common_setup_teardown):
+    a = Input("a", 2)
+    b = Input("b", 3)
+    c = Calculation("c", a + b)
+    calc = Calculation(
+        "calc #1",
+        a - c + brackets(b * a * c) + b - c - a - b,
+        "in",
+        "describing # text",
+        "refer to code",
+    )
+    result = generate_html_for_calc_items([calc])
+    assert calc.estimate_display_length() == CalculationLength.LONG
+    assert calc.name not in result
+    assert "calc \#1" in result
+    assert calc.description in result
+    assert calc.reference in result
+    assert r"\therefore" in result


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the rendering of LaTeX formatted equations by escaping hash characters and update the documentation to version 1.2.4. Add tests to ensure the correct escaping of hash characters in equations.

Bug Fixes:
- Escape hash character in LaTeX formatted equations to ensure correct rendering in HTML output.

Documentation:
- Update documentation to reflect version change from 1.2.3 to 1.2.4 across multiple HTML files.

Tests:
- Add tests to verify that hash characters in equations are correctly escaped in the HTML output.

<!-- Generated by sourcery-ai[bot]: end summary -->