### PR TITLE
Add Jupyter Display Functionality

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov
-        pip install coveralls
+        pip install coveralls ipython
         pip install -r requirements.txt
 
     - name: Test with pytest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest ipython
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/efficalc/report_builder.py
+++ b/efficalc/report_builder.py
@@ -3,6 +3,13 @@ import tempfile
 import webbrowser
 from enum import Enum
 from typing import Callable
+import importlib.util
+
+# Check whether IPython is installed. If so, import HTML display function to render outputs in Jupyter notebook.
+# Do not attempt to import if not installed.
+ipython_installed = importlib.util.find_spec("IPython")
+if ipython_installed:
+    from IPython.display import HTML
 
 from efficalc.calculation_runner import CalculationRunner
 from efficalc.generate_html import generate_html_for_calc_items
@@ -77,6 +84,12 @@ class ReportBuilder(object):
         :rtype: str
         """
         return self.__generate_report_html()
+    
+    def ipy_display(self) -> HTML:
+        """Gets the HTML report and uses IPython to render it as output in a Jupyter notebook.
+        """
+        html_string = self.get_html_as_str()
+        return HTML(html_string)
 
     def save_report(
         self,


### PR DESCRIPTION
This change adds a method `ipy_display` to the `ReportBuilder` class to render calculations in Jupyter notebooks, using `IPython.display.HTML`. IPython installation status is checked before importing to avoid errors for users not working in Jupyter.

## Summary by Sourcery

Add Jupyter display support to ReportBuilder by introducing a notebook-friendly rendering method and guarding IPython imports

New Features:
- Add ipy_display method to ReportBuilder for rendering HTML reports in Jupyter notebooks using IPython.display.HTML

Enhancements:
- Check for IPython availability before importing to avoid errors outside Jupyter environments