### PR TITLE
Remove unused variables to fix tests

### DIFF
--- a/examples/conc_col_pmm/calc_document/try_axis_document.py
+++ b/examples/conc_col_pmm/calc_document/try_axis_document.py
@@ -163,10 +163,6 @@ def try_axis_document(
                 " x coordinate of equivalent compression zone intersection with bottom edge:",
             )
 
-    # define accumulator variables
-    pn_tot = 0
-    mnx_tot = 0
-    mny_tot = 0
 
     if not any(intersects):  # the whole concrete section is in compression
         TextBlock("The equivalent compression zone covers the whole concrete section. ")
@@ -185,7 +181,7 @@ def try_axis_document(
         conc_area_num = 0
 
         def add_axial_moment(pt_a, pt_b, pt_c):
-            nonlocal pn_tot, mnx_tot, mny_tot, conc_area_num
+            nonlocal conc_area_num
             conc_area_num += 1
             Heading("Forces in Concrete Area " + str(conc_area_num), 3)
             TextBlock(


### PR DESCRIPTION
The Github tests were flagging `pn_tot`, `mnx_tot`, and `mny_tot` as unused/never assigned. These variables appear to be initialized as accumulators but never used—maybe left over from a previous version? I've removed them to see if that lets the tests pass. (Everything passes locally with pytest; just need to see if this fixes Github actions.)

## Summary by Sourcery

Bug Fixes:
- Remove unused accumulator variables pn_tot, mnx_tot, and mny_tot and update nonlocal declarations accordingly