### PR TITLE
update tokens for coveralls

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -35,4 +35,5 @@ jobs:
       uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.COVERALLS_GITHUB_TOKEN }}
+        coveralls-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
         path-to-lcov: ./coverage.xml # Make sure this matches the output file from pytest


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Include 'coveralls-token' input in coverallsapp/github-action using the COVERALLS_REPO_TOKEN secret